### PR TITLE
make dustmaps an optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ dependencies = [
   "typing-extensions",
   "pyarango",
   "pydantic>=2",
-  "healpy>=1.18.0",  # healpy 1.18+ supports numpy 2.x
   "scipy>=1.14.0",  # scipy 1.14+ is compatible with numpy 2.x
 
   # only for windows OS b/c it doesn't ship with readline by default
@@ -50,7 +49,6 @@ plotting = [
   # for the plotting
   "matplotlib",
   "plotly",
-
 ]
 
 datafinder = [
@@ -68,6 +66,7 @@ dust = [
   # for dust extinction correction
   "dustmaps",
   "dust_extinction",
+  "healpy>=1.18.0",  # healpy 1.18+ supports numpy 2.x
 ]
 
 standard = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,6 @@ dependencies = [
   "synphot",
   "typing-extensions",
   "pyarango",
-  "dustmaps",
-  "dust_extinction",
   "pydantic>=2",
   "healpy>=1.18.0",  # healpy 1.18+ supports numpy 2.x
   "scipy>=1.14.0",  # scipy 1.14+ is compatible with numpy 2.x
@@ -48,13 +46,14 @@ Home = "https://github.com/astro-otter"
 
 [project.optional-dependencies]
 # other standard dependencies, that are technically optional
-standard = [
-  "tabulate",
-
+plotting = [
   # for the plotting
   "matplotlib",
   "plotly",
 
+]
+
+datafinder = [
   # for the DataFinder query tool
   "astroquery",
   "ads",
@@ -63,6 +62,17 @@ standard = [
   "astro-datalab",
   "sparclclient",
   "wiserep_api",
+]
+
+dust = [
+  # for dust extinction correction
+  "dustmaps",
+  "dust_extinction",
+]
+
+standard = [
+  "tabulate",
+  "astro-otter[plotting,datafinder,dust]"
 ]
 
 # tools for building the readthedocs page

--- a/src/otter/__init__.py
+++ b/src/otter/__init__.py
@@ -10,17 +10,25 @@ from ._version import __version__
 __package__ = "otter"
 
 # lazy load the SFD dust map, if needed
-import os
-import dustmaps
-dustmaps_datapath = os.path.join(
-    os.path.dirname(dustmaps.__file__),
-    "data",
-    "sfd",
-    "SFD_dust_4096_sgp.fits"
-)
-if not os.path.exists(dustmaps_datapath):
-    import dustmaps.sfd
-    dustmaps.sfd.fetch()
+try:
+    import os
+    import dustmaps
+    dustmaps_datapath = os.path.join(
+        os.path.dirname(dustmaps.__file__),
+        "data",
+        "sfd",
+        "SFD_dust_4096_sgp.fits"
+    )
+    if not os.path.exists(dustmaps_datapath):
+        import dustmaps.sfd
+        dustmaps.sfd.fetch()
+except ModuleNotFoundError:
+    logger.warning(
+        "Not loading dustmaps module! This means the photometry may or may not be \
+        MW extinction corrected. We suggest installing dustmaps and/or checking the \
+        photometry"
+    )
+
 
 # import important stuff
 from .io.otter import Otter

--- a/src/otter/io/transient.py
+++ b/src/otter/io/transient.py
@@ -18,8 +18,6 @@ import pandas as pd
 import astropy.units as u
 from astropy.time import Time
 from astropy.coordinates import SkyCoord
-from dust_extinction.parameter_averages import BaseExtRvModel, G23
-from dustmaps.sfd import SFDQuery
 
 from ..exceptions import (
     FailedQueryError,
@@ -983,7 +981,16 @@ class Transient(MutableMapping):
 
         # perform MW dust extinction correction
         if correct_for_mw_dust:
-            outdata = self._correct_for_mw_dust(outdata)
+            try:
+                outdata = self._correct_for_mw_dust(outdata)
+            except ModuleNotFoundError:
+                logger.warning(
+                    "MW Dust correction was requested but can not be"
+                    + "performed because dustmaps is not installed. "
+                    + "The requested photometry MAY OR MAY NOT be extinction "
+                    + "corrected. We suggest checking the photometry or "
+                    + "installing dustmaps."
+                )
 
         # get rid of unsubtracted or unclear subtraction data
         if "corr_host" in outdata and drop_no_host_subtract:
@@ -1044,13 +1051,25 @@ class Transient(MutableMapping):
         Returns:
             The SFD E(B-V) for the MW along this line of sight to the transient.
         """
+        try:
+            from dustmaps.sfd import SFDQuery
+        except ModuleNotFoundError as exc:
+            raise ModuleNotFoundError(
+                "Please install dustmaps to use this method!"
+            ) from exc
+
         skycoord = self.get_skycoord()
         sfd = SFDQuery()
         return sfd(skycoord)
 
     def _correct_for_mw_dust(
-        self, outdata: pd.DataFrame, dust_model: BaseExtRvModel = G23, rv: float = 3.1
+        self, outdata: pd.DataFrame, dust_model=None, rv: float = 3.1
     ) -> pd.DataFrame:
+        if dust_model is None:
+            from dust_extinction.parameter_averages import G23
+
+            dust_model = G23
+
         extmod = dust_model(Rv=rv)
         ebv = self.get_ebv()
         wave_unit = u.Unit(outdata.converted_wave_unit.values[0])


### PR DESCRIPTION
This moves dustmaps and dust extinction correction to an optional dependency allowing for easier installation for users who wish to perform the MW extinction correction on their end. 